### PR TITLE
Fix gradient text display issue on main page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ import { useTasks } from '@/hooks/useTasks';
 import { useUserProfile } from '@/hooks/useUserProfile';
 import { toast, Toaster } from 'sonner';
 import { motion } from 'framer-motion';
-import { Heart, Target } from 'lucide-react';
+import { Heart, Target, Sparkles } from 'lucide-react';
 
 export default function Home() {
   const [mounted, setMounted] = useState(false);


### PR DESCRIPTION
Fixes #3

Added missing Sparkles import from lucide-react that was causing the 'Ready to shine today?' text to fail rendering properly. The gradient styling was already correct but the missing import prevented the page from displaying the gradient text effect.

🤖 Generated with [Claude Code](https://claude.ai/code)